### PR TITLE
feature(config): adding config.ignore to replace metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ playground for learning and exploring.
 * **MD038** - Spaces inside code span elements
 * **MD039** - Spaces inside link text
 * **MD040** - Fenced code blocks should have a language specified
+* **ignore** - Ignore certain parts of the markdown file (can be `RegExp`, `Function`, `"frontmatter"`), should be used with disabled `MD012`
 
 See [Rules.md](doc/Rules.md) for more details.
 

--- a/lib/markdownlint.js
+++ b/lib/markdownlint.js
@@ -53,8 +53,24 @@ function uniqueFilterForSorted(value, index, array) {
   return (index === 0) || (value > array[index - 1]);
 }
 
+function ignoreContent(content, config) {
+  if (typeof config.ignore === "function") {
+    // allow custom ignore callback
+    return config.ignore(content);
+  }
+
+  return content.replace(config.ignore, function removeNonLineBreaks(m) {
+    // maintain line breaks
+    return m.replace(/[^\n]+/g, "");
+  });
+}
+
 // Lints a single string
 function lintContent(content, config) {
+  // ignore portions of content
+  if (config.ignore) {
+    content = ignoreContent(content, config);
+  }
   // Parse content into tokens and lines
   var tokens = md.parse(content, {});
   var lines = content.split(shared.newLineRe);
@@ -170,6 +186,18 @@ function markdownlint(options, callback) {
   var config = options.config || { "default": true };
   var synchronous = (callback === markdownlintSynchronousCallback);
   var results = new Results();
+  if (config.ignore) {
+    if (config.ignore === "frontmatter") {
+      // see http://jekyllrb.com/docs/frontmatter/
+      config.ignore = /^---([\s\S]+?)---/;
+    }
+    if (typeof config.ignore !== "function" &&
+      !config.ignore.test &&
+      !config.ignore.exec
+    ) {
+      throw new TypeError("config.ignore must be a RegExp or Function");
+    }
+  }
   // Helper to lint the next file in the array
   function lintFilesArray() {
     var file = files.shift();

--- a/test/ignore_frontmatter.json
+++ b/test/ignore_frontmatter.json
@@ -1,0 +1,5 @@
+{
+  "default": true,
+  "ignore": "frontmatter",
+  "MD012": false
+}

--- a/test/ignore_frontmatter.md
+++ b/test/ignore_frontmatter.md
@@ -1,0 +1,7 @@
+---
+front: matter
+---
+
+# Header 1 #
+
+## Header 2 ##


### PR DESCRIPTION
My markdown files contain [frontmatter](http://jekyllrb.com/docs/frontmatter/) to configure the documentation build system. That code is erroneously detected as a headline and subsequently fails MD002 and MD003. (github displays the frontmatter as a table). Should you wish to parse the the frontmatter properly, the [gray-matter](https://www.npmjs.com/package/gray-matter) package might be a good place to start.

This PR adds the config option `ignore` with which any part of a markdown file can be replaced by line breaks (to preserve the line-markings of the actual tests) before the markdown file is linted. Because frontmatter seems to be used by a couple of systems (Jekyll and metalsmith being the ones I use), I added the regular expression to your code directly and acitvating it if `config.ignore === 'frontmatter'` is passed in.

Cheers!