### PR TITLE
Adding link to remark-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ cases come directly from that project.
 * [markdownlint-cli command-line interface for Node.js](https://github.com/igorshubovych/markdownlint-cli)
 * [vscode-markdownlint extension for VS Code](https://marketplace.visualstudio.com/items/DavidAnson.vscode-markdownlint)
 * [markdownlint/mdl gem for Ruby](https://rubygems.org/gems/mdl)
+* [remark-lint](https://github.com/wooorm/remark-lint) - linter based on [remark](https://github.com/wooorm/remark)
 
 ## Demonstration
 


### PR DESCRIPTION
Adding link to related project Remark-Lint:
https://github.com/wooorm/remark-lint