### PR TITLE
MD027 should support blockquote nesting

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -575,17 +575,17 @@ module.exports = [
     "tags": [ "blockquote", "whitespace", "indentation" ],
     "aliases": [ "no-multiple-space-blockquote" ],
     "func": function MD027(params, errors) {
-      var inBlockquote = false;
+      var blockquoteNesting = 0;
       params.tokens.forEach(function forToken(token) {
         if (token.type === "blockquote_open") {
-          inBlockquote = true;
+          blockquoteNesting++;
         } else if (token.type === "blockquote_close") {
-          inBlockquote = false;
-        } else if ((token.type === "inline") && inBlockquote) {
+          blockquoteNesting--;
+        } else if ((token.type === "inline") && blockquoteNesting > 0) {
           token.content.split(shared.newLineRe)
             .forEach(function forLine(line, offset) {
               if (/^\s/.test(line) ||
-                  (!offset && /^\s*>\s\s/.test(token.line))) {
+                  (!offset && /^(\s*>)+\s\s/.test(token.line))) {
                 errors.push(token.lineNumber + offset);
               }
             });

--- a/test/blockquote_spaces.md
+++ b/test/blockquote_spaces.md
@@ -21,3 +21,11 @@ Test the first line being indented too much:
 >  Foo {MD027}
 >  Bar {MD027}
 > Baz
+
+Nested blockquote
+
+>  A {MD027}
+>
+> >  B {MD027}
+>
+>  C {MD027}


### PR DESCRIPTION
A, B, and C have two spaces after `>`.
Each of them should be reported as MD027 (Multiple spaces after blockquote symbol),
but only A is reported.

```md
>  A
>
> >  B
>
>  C
```
