### PR TITLE
Add support to run markdownlint with pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 -   id: markdownlint
     name: markdownlint
-    description: "Check the style of Markdown/Commonmark files"
+    description: "Checks the style of Markdown/Commonmark files."
     entry: markdownlint
     language: node
     types: [markdown]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+-   id: markdownlint
+    name: markdownlint
+    description: "Check the style of Markdown/Commonmark files"
+    entry: markdownlint
+    language: node
+    types: [markdown]
+    minimum_pre_commit_version: 0.15.0


### PR DESCRIPTION
This PR adds the ability to use `markdownlint` as [pre-commit](http://pre-commit.com/) hook.