### PR TITLE
docs: Point to markdownlint-rules keyword on NPM

### DIFF
--- a/doc/CustomRules.md
+++ b/doc/CustomRules.md
@@ -1,7 +1,7 @@
 # Custom Rules
 
 In addition to its built-in rules, `markdownlint` lets you enhance the linting experience by passing a list of custom rules using the [`options.customRules` property](../README.md#optionscustomrules).
-Custom rules can do everything the built-in rules can and are defined inline or imported from another package (keyword `markdownlint-rules` on [npm](https://www.npmjs.com/)).
+Custom rules can do everything the built-in rules can and are defined inline or imported from another package ([keyword `markdownlint-rules` on npm](https://www.npmjs.com/search?q=keywords:markdownlint-rules)).
 Custom rules can be disabled, enabled, and customized using the same syntax as built-in rules.
 
 ## Authoring


### PR DESCRIPTION
There doesn't look to be any results right now, but might be good for the future.
Not sure if the link should cover less of the text