### PR TITLE
Rules: update MD032 removing deprecated paragraph

### DIFF
--- a/doc/Rules.md
+++ b/doc/Rules.md
@@ -1095,17 +1095,6 @@ Some text
 Rationale: Aside from aesthetic reasons, some parsers, including kramdown, will
 not parse lists that don't have blank lines before and after them.
 
-Note: List items without hanging indents are a violation of this rule; list
-items with hanging indents are okay:
-
-```markdown
-* This is
-not okay
-
-* This is
-  okay
-```
-
 <a name="md033"></a>
 
 ## MD033 - Inline HTML


### PR DESCRIPTION
Closes #211.

Also, I was wondering about this paragraph:

> This rule is triggered when lists (of any kind) are either not preceded **or not
followed by a blank line**
>
> ```markdown
> Some text
> * Some
> * List
> 
> 1. Some
> 2. List
> Some text
> ```

Doesn't the fact that "lazy continuation" is allowed basically contradict the second part of this sentence? In other words, would a final list item *not* followed by a blank line always be treated as lazy continuation and therefore never trigger this rule?