### PR TITLE
fix: allow for first level indentation of lists (#242)

### DIFF
--- a/doc/Rules.md
+++ b/doc/Rules.md
@@ -273,7 +273,7 @@ Tags: bullet, ul, indentation
 
 Aliases: ul-indent
 
-Parameters: indent (number; default 2)
+Parameters: indent, start_indented (number; default 2, boolean; default false)
 
 This rule is triggered when list items are not indented by the configured
 number of spaces (default: 2).
@@ -309,6 +309,10 @@ for a description of the problem.
 Note: This rule applies to a sublist only if its parent lists are all also
 unordered (otherwise, extra indentation of ordered lists interferes with the
 rule).
+
+The `start_indented` parameter allows the first level of lists to be indented by
+the configured number of spaces rather than starting at zero (the inverse of
+MD006).
 
 <a name="md009"></a>
 

--- a/lib/md007.js
+++ b/lib/md007.js
@@ -11,12 +11,14 @@ module.exports = {
   "description": "Unordered list indentation",
   "tags": [ "bullet", "ul", "indentation" ],
   "function": function MD007(params, onError) {
-    const optionsIndent = params.config.indent || 2;
+    const indent = params.config.indent || 2;
+    const startIndented = !!params.config.start_indented;
     flattenedLists().forEach((list) => {
       if (list.unordered && list.parentsUnordered) {
         list.items.forEach((item) => {
           const { lineNumber, line } = item;
-          const expectedIndent = list.nesting * optionsIndent;
+          const expectedNesting = list.nesting + (startIndented ? 1 : 0);
+          const expectedIndent = expectedNesting * indent;
           const actualIndent = indentFor(item);
           let range = null;
           let editColumn = 1;

--- a/schema/build-config-schema.js
+++ b/schema/build-config-schema.js
@@ -95,6 +95,11 @@ rules.forEach(function forRule(rule) {
           "description": "Spaces for indent",
           "type": "integer",
           "default": 2
+        },
+        "start_indented": {
+          "description": "Whether to indent the first level of the list",
+          "type": "boolean",
+          "default": false
         }
       };
       break;

--- a/schema/markdownlint-config-schema.json
+++ b/schema/markdownlint-config-schema.json
@@ -230,6 +230,11 @@
           "description": "Spaces for indent",
           "type": "integer",
           "default": 2
+        },
+        "start_indented": {
+          "description": "Whether to indent the first level of the list",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false
@@ -246,6 +251,11 @@
           "description": "Spaces for indent",
           "type": "integer",
           "default": 2
+        },
+        "start_indented": {
+          "description": "Whether to indent the first level of the list",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/test/list-indentation-start-indented.json
+++ b/test/list-indentation-start-indented.json
@@ -1,0 +1,8 @@
+{
+  "default": true,
+  "MD006": false,
+  "MD007": {
+    "indent": 3,
+    "start_indented": true
+  }
+}

--- a/test/list-indentation-start-indented.md
+++ b/test/list-indentation-start-indented.md
@@ -1,0 +1,39 @@
+# List Indentation - Start Indented
+
+   * item 1
+   * item 2
+      * item 2.1
+      * item 2.2
+         * item 2.2.1
+      * item 2.3
+   * item 3
+
+## Disallowed List Indentation - Starts at Zero
+
+* item 1 {MD007}
+* item 2 {MD007}
+   * item 2.1 {MD007}
+   * item 2.2 {MD007}
+      * item 2.2.1 {MD007}
+   * item 2.3 {MD007}
+* item 3 {MD007}
+
+## Disallowed List Indentation - Starts at One
+
+ * item 1 {MD007}
+ * item 2 {MD007}
+    * item 2.1 {MD007}
+    * item 2.2 {MD007}
+       * item 2.2.1 {MD007}
+    * item 2.3 {MD007}
+ * item 3 {MD007}
+
+## Disallowed List Indentation - Starts at Two
+
+  * item 1 {MD007}
+  * item 2 {MD007}
+     * item 2.1 {MD007}
+     * item 2.2 {MD007}
+        * item 2.2.1 {MD007}
+     * item 2.3 {MD007}
+  * item 3 {MD007}

--- a/test/list-indentation.md
+++ b/test/list-indentation.md
@@ -44,3 +44,13 @@ Text
   - Item {MD005}
 
 Text
+
+## Invalid Indentation - Should Start at Zero
+
+  - item 1 {MD006} {MD007}
+  - item 2 {MD006} {MD007}
+    - item 2.1 {MD007}
+    - item 2.2 {MD007}
+      - item 2.2.1 {MD007}
+    - item 2.3 {MD007}
+  - item 3 {MD006} {MD007}


### PR DESCRIPTION
This is a proposed fix for #242. It should maintain backwards-compatibility, while allowing users like me to achieve our goal as well. If there's a different way you'd like it implemented, I'm happy to rework it with your direction.