### PR TITLE
Fix NPE with wrapped links

### DIFF
--- a/lib/md039.js
+++ b/lib/md039.js
@@ -4,7 +4,7 @@
 
 const { addErrorContext, filterTokens } = require("../helpers");
 
-const spaceInLinkRe = /\[(?:\s+(?:[^\]]*?)\s*|(?:[^\]]*?)\s+)](?=\(\S*\))/;
+const spaceInLinkRe = /\[|^(?:\s+(?:[^\]]*?)\s*|(?:[^\]]*?)\s+)](?=\(\S*\))/;
 
 module.exports = {
   "names": [ "MD039", "no-space-in-links" ],


### PR DESCRIPTION
The regex change addresses an issue when due to automated line wrapping or other f-ups links get wrapped like this:

```markdown
* This is a badly wrapped [ Link with a leading space
     ](https://acme.com)
```

Before the change, the failed match would result in an NPE:

```
root/node_modules/markdownlint/lib/markdownlint.js:648
      throw error;
      ^

TypeError: Cannot read property 'index' of null
    at root/node_modules/markdownlint/lib/md039.js:32:34
    at Array.forEach (<anonymous>)
    at root/node_modules/markdownlint/lib/md039.js:20:16
    at forToken (root/node_modules/markdownlint/helpers/helpers.js:151:7)
    at Array.forEach (<anonymous>)
    at filterTokens (root/node_modules/markdownlint/helpers/helpers.js:149:17)
    at Object.MD039 [as function] (root/node_modules/markdownlint/lib/md039.js:14:5)
    at forRule (root/node_modules/markdownlint/lib/markdownlint.js:466:20)
    at Array.forEach (<anonymous>)
    at lintContent (root/node_modules/markdownlint/lib/markdownlint.js:512:14)
```

Alternatively, one could add error handling to ensure the regex actually matches:

```javascript
// Before line 32
if(!match) console.error("Could not match " + line");
```