### PR TITLE
Document which rules exist only in Node/Ruby implementations

### DIFF
--- a/doc/Rules.md
+++ b/doc/Rules.md
@@ -1581,6 +1581,8 @@ information: <https://cirosantilli.com/markdown-style-guide#top-level-header>.
 
 ## MD042 - No empty links
 
+Availability: Node version only
+
 Tags: links
 
 Aliases: no-empty-links
@@ -1614,6 +1616,8 @@ Rationale: Empty links do not lead anywhere and therefore don't function as link
 <a name="md043"></a>
 
 ## MD043 - Required heading structure
+
+Availability: Node version only
 
 Tags: headings, headers
 
@@ -1681,6 +1685,8 @@ a set of similar content.
 
 ## MD044 - Proper names should have the correct capitalization
 
+Availability: Node version only
+
 Tags: spelling
 
 Aliases: proper-names
@@ -1710,6 +1716,8 @@ Rationale: Incorrect capitalization of proper names is usually a mistake.
 <a name="md045"></a>
 
 ## MD045 - Images should have alternate text (alt text)
+
+Availability: Node version only
 
 Tags: accessibility, images
 
@@ -1743,6 +1751,8 @@ content of an image for people who may not be able to see it.
 <a name="md046"></a>
 
 ## MD046 - Code block style
+
+Availability: Ruby version only
 
 Tags: code
 


### PR DESCRIPTION
I encountered this when trying to configure the 'proper-names' rule:

```
RuntimeError: No such rule: MD044
```

It looks as though several rules are platform-specific, according to:
https://dev.to/jonasbn/blog-post-markdownlint-24ig

Thanks for this project - super useful!

EDIT: have just seen the [CONTRIBUTING.md](https://github.com/DavidAnson/markdownlint/blob/main/CONTRIBUTING.md). I can turn this into an issue if you prefer and we can discuss how best to represent status.