### PR TITLE
chore: Rename 'ci' script conflicting with NPM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       run: npm install --no-package-lock
     - name: Run All Validations
       if: ${{ matrix.node-version == '14.x' }}
-      run: npm run ci
+      run: npm run test-ci
     - name: Run Tests Only
       if: ${{ matrix.node-version != '14.x' }}
       run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,34 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
-      run: npm install --no-package-lock
-    - name: Run All Validations
+      run: npm install
+    - name: Run tests with coverage
       if: ${{ matrix.node-version == '14.x' }}
-      run: npm run test-ci
+      run: npm run test-cover
     - name: Run Tests Only
       if: ${{ matrix.node-version != '14.x' }}
       run: npm run test
+
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+    - name: Install Dependencies
+      run: npm install
+    - name: Lint
+      run: npm run lint
+
+  declaration:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Dependencies
+      run: npm install
+    - name: Run Typescript Validations
+      run: npm run test-declaration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ If `some-test.md` needs custom configuration, a `some-test.json` is used to prov
 Lint before sending a pull request by running `npm run lint`.
 There should be no issues.
 
-Run a full continuous integration pass before sending a pull request via `npm run ci`.
+Run a full continuous integration pass before sending a pull request via `npm run gh-ci`.
 Code coverage should remain at 100%.
 
 Pull requests should contain a single commit.

--- a/demo/markdownlint-browser.js
+++ b/demo/markdownlint-browser.js
@@ -3521,7 +3521,7 @@ module.exports={
         "test-declaration": "cd example/typescript && tsc && node type-check.js",
         "test-extra": "node test/markdownlint-test-extra.js",
         "lint": "eslint --max-warnings 0 lib helpers test schema && eslint --env browser --global markdownit --global markdownlint --rule \"no-unused-vars: 0, no-extend-native: 0, max-statements: 0, no-console: 0, no-var: 0, unicorn/prefer-add-event-listener: 0, unicorn/prefer-query-selector: 0, unicorn/prefer-replace-all: 0\" demo && eslint --rule \"no-console: 0, no-invalid-this: 0, no-shadow: 0, object-property-newline: 0, node/no-missing-require: 0, node/no-extraneous-require: 0\" example",
-        "ci": "npm run test-cover && npm run lint && npm run test-declaration",
+        "gh-ci": "npm run test-cover && npm run lint && npm run test-declaration",
         "build-config-schema": "node schema/build-config-schema.js",
         "build-declaration": "tsc --allowJs --declaration --emitDeclarationOnly --resolveJsonModule lib/markdownlint.js && rimraf 'lib/{c,md,r}*.d.ts' 'helpers/*.d.ts'",
         "build-demo": "cpy node_modules/markdown-it/dist/markdown-it.min.js demo && cd demo && rimraf markdownlint-browser.* && cpy file-header.js . --rename=markdownlint-browser.js && tsc --allowJs --resolveJsonModule --outDir ../lib-es3 ../lib/markdownlint.js && cpy ../helpers/package.json ../lib-es3/helpers && browserify ../lib-es3/lib/markdownlint.js --standalone markdownlint >> markdownlint-browser.js && browserify ../lib-es3/helpers/helpers.js --standalone helpers >> markdownlint-rule-helpers-browser.js && uglifyjs markdownlint-browser.js markdownlint-rule-helpers-browser.js --compress --mangle --comments --output markdownlint-browser.min.js",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test-declaration": "cd example/typescript && tsc && node type-check.js",
     "test-extra": "node test/markdownlint-test-extra.js",
     "lint": "eslint --max-warnings 0 .",
-    "ci": "npm run test-cover && npm run lint && npm run test-declaration",
+    "gh-ci": "npm run test-cover && npm run lint && npm run test-declaration",
     "build-config-schema": "node schema/build-config-schema.js",
     "build-declaration": "tsc --allowJs --declaration --emitDeclarationOnly --resolveJsonModule lib/markdownlint.js && rimraf 'lib/{c,md,r}*.d.ts' 'helpers/*.d.ts'",
     "build-demo": "cpy node_modules/markdown-it/dist/markdown-it.min.js demo && cd demo && rimraf markdownlint-browser.* && cpy file-header.js . --rename=markdownlint-browser.js && tsc --allowJs --resolveJsonModule --outDir ../lib-es3 ../lib/markdownlint.js && cpy ../helpers/package.json ../lib-es3/helpers && browserify ../lib-es3/lib/markdownlint.js --standalone markdownlint >> markdownlint-browser.js && browserify ../lib-es3/helpers/helpers.js --standalone helpers >> markdownlint-rule-helpers-browser.js && uglifyjs markdownlint-browser.js markdownlint-rule-helpers-browser.js --compress --mangle --comments --output markdownlint-browser.min.js",


### PR DESCRIPTION
`npm ci` without the run is a first party command, so renaming it to prevent confusion