### PR TITLE
Correct typo in JSON schema `type` keyword

### DIFF
--- a/schema/build-config-schema.js
+++ b/schema/build-config-schema.js
@@ -32,7 +32,7 @@ const schema = {
     }
   },
   "additionalProperties": {
-    "type:": [
+    "type": [
       "boolean",
       "object"
     ]

--- a/schema/markdownlint-config-schema.json
+++ b/schema/markdownlint-config-schema.json
@@ -1561,7 +1561,7 @@
     }
   },
   "additionalProperties": {
-    "type:": [
+    "type": [
       "boolean",
       "object"
     ]


### PR DESCRIPTION
A typo caused the markdownlint configuration JSON schema to contain an invalid keyword named `type:` rather than the intended `type` keyword.