### PR TITLE
Remove Node 10.x logic from CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Install Dependencies
       run: npm install --no-package-lock
     - name: Run All Validations
-      if: ${{ matrix.node-version != '10.x' && matrix.node-version != '12.x' }}
+      if: ${{ matrix.node-version != '12.x' }}
       run: npm run ci
     - name: Run Tests Only
-      if: ${{ matrix.node-version == '10.x' || matrix.node-version == '12.x' }}
+      if: ${{ matrix.node-version == '12.x' }}
       run: npm run test


### PR DESCRIPTION
Node 10.x is not included in the matrix configuration in the CI workflow, so this logic can be removed.