### PR TITLE
Remove need for process.platform in applyFixes

### DIFF
--- a/demo/markdownlint-browser.js
+++ b/demo/markdownlint-browser.js
@@ -727,8 +727,8 @@ function applyFix(line, fixInfo, lineEnding) {
 }
 module.exports.applyFix = applyFix;
 // Applies as many fixes as possible to the input lines
-module.exports.applyFixes = function applyFixes(input, errors) {
-    var lineEnding = getPreferredLineEnding(input);
+module.exports.applyFixes = function applyFixes(input, errors, platform) {
+    var lineEnding = getPreferredLineEnding(input, platform);
     var lines = input.split(newLineRe);
     // Normalize fixInfo objects
     var fixInfos = errors

--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -751,8 +751,8 @@ function applyFix(line, fixInfo, lineEnding) {
 module.exports.applyFix = applyFix;
 
 // Applies as many fixes as possible to the input lines
-module.exports.applyFixes = function applyFixes(input, errors) {
-  const lineEnding = getPreferredLineEnding(input);
+module.exports.applyFixes = function applyFixes(input, errors, platform) {
+  const lineEnding = getPreferredLineEnding(input, platform);
   const lines = input.split(newLineRe);
   // Normalize fixInfo objects
   let fixInfos = errors


### PR DESCRIPTION
Related to fd24b9552be8ca6eb543cf3f74fdccb44c9959cb

Also pass platform argument for `applyFixes` call to remove dependency on `process.platform` if line ending can't be determined from the document content.