### PR TITLE
doc: clarify description for MD026 punctuation

### DIFF
--- a/schema/.markdownlint.jsonc
+++ b/schema/.markdownlint.jsonc
@@ -139,7 +139,7 @@
 
   // MD026/no-trailing-punctuation - Trailing punctuation in heading
   "MD026": {
-    // Punctuation characters
+    // Punctuation characters not allowed at end of headings
     "punctuation": ".,;:!。，；：！"
   },
 

--- a/schema/.markdownlint.yaml
+++ b/schema/.markdownlint.yaml
@@ -127,7 +127,7 @@ MD025:
 
 # MD026/no-trailing-punctuation - Trailing punctuation in heading
 MD026:
-  # Punctuation characters
+  # Punctuation characters not allowed at end of headings
   punctuation: ".,;:!。，；：！"
 
 # MD027/no-multiple-space-blockquote - Multiple spaces after blockquote symbol

--- a/schema/build-config-schema.js
+++ b/schema/build-config-schema.js
@@ -258,7 +258,7 @@ for (const rule of rules) {
     case "MD026":
       scheme.properties = {
         "punctuation": {
-          "description": "Punctuation characters",
+          "description": "Punctuation characters not allowed at end of headings",
           "type": "string",
           "default": ".,;:!。，；：！"
         }

--- a/schema/build-config-schema.js
+++ b/schema/build-config-schema.js
@@ -258,7 +258,8 @@ for (const rule of rules) {
     case "MD026":
       scheme.properties = {
         "punctuation": {
-          "description": "Punctuation characters not allowed at end of headings",
+          "description":
+            "Punctuation characters not allowed at end of headings",
           "type": "string",
           "default": ".,;:!。，；：！"
         }

--- a/schema/markdownlint-config-schema.json
+++ b/schema/markdownlint-config-schema.json
@@ -456,7 +456,7 @@
       "default": true,
       "properties": {
         "punctuation": {
-          "description": "Punctuation characters",
+          "description": "Punctuation characters not allowed at end of headings",
           "type": "string",
           "default": ".,;:!。，；：！"
         }


### PR DESCRIPTION
Was trying to customize the rule on a repo and couldn't easily tell from the current metadata if it was an allow or a disallow list of characters.

There is a similar ambiguity in the MD036 rule