### PR TITLE
fix(prettier): add ordered list configuration.

### DIFF
--- a/doc/Prettier.md
+++ b/doc/Prettier.md
@@ -21,7 +21,8 @@ to `4`, the following `markdownlint` configuration can be used:
   },
   "MD030": {
     "ul_single": 3,
-    "ul_multi": 3
+    "ul_multi": 3,
+    "ol_multi": 2
   }
 }
 ```


### PR DESCRIPTION
Whilst testing earlier today with [pre-commit](https://github.com/pre-commit/pre-commit) I was getting a conflict between `prettier` and `markdownlint-cli2` when it came to ordered lists with multiple paragraphs.

Running either in isolation was fine, and would re-format the files to their own liking.  However when combined it started a bun fight over spacing.

Basically the same issue as described in #410 but for ordered rather than unordered lists, hence not opening a new issue before submitting this pull request.

To resolve I had to add `ol_multi: 2` into the `.markdownlint-cli2.yaml` config.

As I'd already done the work to solve it I'm submitting this in-case you want to update the config suggested in [Prettier.md](doc/Prettier.md).


Abbreviated files were:

### .editorconfig
```editorconfig
root = true

[*]
charset = utf-8
end_of_line = lf
indent_size = 4
indent_style = space
insert_final_newline = true
trim_trailing_whitespace = true

[*.md]
trim_trailing_whitespace = false
```

### README.md
```markdown
1.  Line 1
2.  Line 2

    ```json
    { }
    ```

3.  Line 3
```

### .pre-commit-config.yaml
```yaml
%YAML 1.2
# yaml-language-server: $schema=https://json.schemastore.org/pre-commit-config.json
---
default_install_hook_types:
    - pre-commit

default_stages:
    - commit

fail_fast: true

repos:
    - repo: https://github.com/DavidAnson/markdownlint-cli2/
      rev: v0.5.1
      hooks:
          - id: markdownlint-cli2
            additional_dependencies:
                - markdownlint-rule-titlecase
                - markdownlint-cli2-formatter-junit

    - repo: https://github.com/pre-commit/mirrors-prettier
      rev: v3.0.0-alpha.4
      hooks:
          - id: prettier
            additional_dependencies:
                - prettier@3.0.0-alpha.4
                - eslint-config-prettier
                - stylelint-config-prettier
                - prettier-plugin-java
                - prettier-plugin-sh
                - prettier-plugin-toml
                - "@prettier/plugin-xml"
```

### .markdownlint-cli2.yaml
```yaml
%YAML 1.2
---
config:
    default: true
    MD007:
        indent: 4
    MD013: false
    MD030:
        ul_single: 3
        ul_multi: 3
        ol_multi: 2

customRules:
    - "markdownlint-rule-titlecase"

fix: true

noInlineConfig: true

outputFormatters:
    - - markdownlint-cli2-formatter-default
    - - markdownlint-cli2-formatter-junit
```


Signed-off-by: Adam Moss <2951486+adam-moss@users.noreply.github.com>