### PR TITLE
Mention 'markdownlint-rule-search-replace' rule in documentation

### DIFF
--- a/.github/dictionary.txt
+++ b/.github/dictionary.txt
@@ -20,8 +20,8 @@ CodeQL
 CodiMD
 CommonMark
 config
-Config
 config.
+Config
 CVE-2022-21670
 docs-util
 ES2015
@@ -48,6 +48,7 @@ markdownlint
 markdownlint-cli
 markdownlint-cli2
 markdownlint-rule-helpers
+markdownlint-rule-search-replace
 matcher
 MD\d\d\d
 MD\d\d\d-MD\d\d\d
@@ -79,9 +80,9 @@ Reactable
 README
 reimplement
 setext
+setext-style
 setext_with_atx
 setext_with_atx_closed
-setext-style
 single-h1
 sublist
 Super-Linter
@@ -90,8 +91,8 @@ TOML
 trimLeft
 trimRight
 ul
-ul_single
 ul-indent
+ul_single
 ul-start-left
 ul-style
 unhandled

--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ See [Rules.md](doc/Rules.md) for more details.
 > aliases (e.g. `heading-increment` is also available as `header-increment`).
 > The use of `header` is deprecated and provided for backward-compatibility.
 
+### Custom Rules
+
+In addition to built-in rules, custom rules can be used to address
+project-specific requirements. To find community-developed rules use
+[keyword `markdownlint-rule` on npm][markdownlint-rule].
+To implement your own rules, refer to [CustomRules.md](doc/CustomRules.md).
+
+[markdownlint-rule]: https://www.npmjs.com/search?q=keywords:markdownlint-rule
+
 ## Tags
 
 Tags group related rules and can be used to enable/disable multiple
@@ -460,10 +469,7 @@ Type: `Array` of `Object`
 List of custom rules to include with the default rule set for linting.
 
 Each array element should define a rule. Rules are typically exported
-by another package, but can be defined locally. Custom rules are
-identified by the [keyword `markdownlint-rule` on npm][markdownlint-rule].
-
-[markdownlint-rule]: https://www.npmjs.com/search?q=keywords:markdownlint-rule
+by another package, but can be defined locally.
 
 Example:
 

--- a/doc/CustomRules.md
+++ b/doc/CustomRules.md
@@ -7,6 +7,17 @@ rules can and are defined inline or imported from another package ([keyword
 `markdownlint-rule` on npm][markdownlint-rule]). Custom rules can be disabled,
 enabled, and customized using the same syntax as built-in rules.
 
+## Implementing Simple Rules
+
+For simple requirements like disallowing certain characters or patterns,
+the community-developed
+[markdownlint-rule-search-replace][markdownlint-rule-search-replace]
+plug-in can be used.
+This plug-in allows anyone to create a set of simple text-replacement rules in
+JSON without needing to write any code.
+
+[markdownlint-rule-search-replace]: https://www.npmjs.com/package/markdownlint-rule-search-replace
+
 ## Authoring
 
 Rules are defined by a name (or multiple names), a description, an optional link
@@ -85,7 +96,7 @@ properties:
         characters to delete (the value `-1` is used to delete the line).
       - `insertText` is an optional `String` specifying the text to insert. `\n`
         is the platform-independent way to add a line break; line breaks should
-        be added at the beginning of a line instead of at the end).
+        be added at the beginning of a line instead of at the end.
 
 The collection of helper functions shared by the built-in rules is available for
 use by custom rules in the [markdownlint-rule-helpers package][rule-helpers].

--- a/test/markdownlint-test.js
+++ b/test/markdownlint-test.js
@@ -654,6 +654,7 @@ test("readmeHeadings", (t) => new Promise((resolve) => {
           "### Related",
           "## Demonstration",
           "## Rules / Aliases",
+          "### Custom Rules",
           "## Tags",
           "## Configuration",
           "## API",


### PR DESCRIPTION
Addresses https://github.com/DavidAnson/markdownlint/issues/673#issuecomment-1343033848.

Changes:
- To make custom rules feature more noticeable added a separate section for it in README.md. 
- The `markdownlint-rule-search-replace` makes it easy to create simple custom rules. The PR adds mention of it in CustomRules.md.

