### PR TITLE
Improved YAML Schema build (#721)

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "tv4": "1.3.0",
     "typescript": "4.9.4",
     "webpack": "5.75.0",
-    "webpack-cli": "5.0.1"
+    "webpack-cli": "5.0.1",
+    "yaml": "^2.2.1"
   },
   "keywords": [
     "markdown",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "typescript": "4.9.4",
     "webpack": "5.75.0",
     "webpack-cli": "5.0.1",
-    "yaml": "^2.2.1"
+    "yaml": "2.2.1"
   },
   "keywords": [
     "markdown",

--- a/schema/.markdownlint.jsonc
+++ b/schema/.markdownlint.jsonc
@@ -1,5 +1,5 @@
+// Example markdownlint configuration with all properties set to their default value
 {
-  // Example markdownlint JSON(C) configuration with all properties set to their default value
 
   // Default state for all rules
   "default": true,

--- a/schema/.markdownlint.yaml
+++ b/schema/.markdownlint.yaml
@@ -257,6 +257,5 @@ MD052: true
 # MD053/link-image-reference-definitions - Link and image reference definitions should be needed
 MD053:
   # Ignored definitions
-  ignored_definitions: [
-    "//"
-  ]
+  ignored_definitions:
+    - "//"

--- a/schema/.markdownlint.yaml
+++ b/schema/.markdownlint.yaml
@@ -1,4 +1,4 @@
-# Example markdownlint YAML configuration with all properties set to their default value
+# Example markdownlint configuration with all properties set to their default value
 
 # Default state for all rules
 default: true

--- a/schema/build-config-example.js
+++ b/schema/build-config-example.js
@@ -5,6 +5,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const configSchema = require("./markdownlint-config-schema.json");
+const YAML = require("yaml");
 
 const configExample = {};
 for (const rule in configSchema.properties) {
@@ -36,18 +37,17 @@ fs.writeFileSync(
   "utf8"
 );
 
-const configStringYaml = configStringJson
-  .replace(/JSON\(C\)/, "YAML")
-  .replace(/\n {2}/g, "\n")
-  .replace(/\/\/ /g, "# ")
-  .replace(/(\s*)"([^"]+)":/g, "$1$2:")
-  .replace(/: \{/g, ":")
-  .replace(/\n\}/g, "")
-  .replace(/,\n/g, "\n")
-  .replace(/^\{\n/, "")
-  .replace(/\}$/, "");
+const configStringYaml = YAML.stringify(configExample, {
+  "lineWidth": 0,
+  "defaultStringType": "QUOTE_DOUBLE",
+  "defaultKeyType": "PLAIN"
+})
+  .replace(/^(\s*)[^-\s]+-sub-description: "(.+)"$/gm, "$1# $2")
+  .replace(/^[^-\s]+-description: "(.+)"$/gm, "\n# $1");
 fs.writeFileSync(
   path.join(__dirname, ".markdownlint.yaml"),
+  // eslint-disable-next-line max-len
+  "# Example markdownlint YAML configuration with all properties set to their default value\n" +
   configStringYaml,
   "utf8"
 );

--- a/schema/build-config-example.js
+++ b/schema/build-config-example.js
@@ -26,28 +26,31 @@ for (const rule in configSchema.properties) {
   }
 }
 
-const configStringJson = JSON.stringify(configExample, null, 2)
+const transferComments = (input, commentLiterals) => commentLiterals +
   // eslint-disable-next-line max-len
-  .replace(/^\{/, "{\n  // Example markdownlint JSON(C) configuration with all properties set to their default value")
-  .replace(/(\s+)"[^-"]+-description": "(.+)",/g, "\n$1// $2")
-  .replace(/"[^-"]+-sub-description": "(.+)",/g, "// $1");
+  " Example markdownlint configuration with all properties set to their default value\n" +
+  input
+    // eslint-disable-next-line max-len
+    .replace(/^(\s*)"?[^-\s]+-sub-description"?: "?([^"\n]+)"?,?$/gm, "$1" + commentLiterals + " $2")
+    // eslint-disable-next-line max-len
+    .replace(/^(\s*)"?[^-\s]+-description"?: "?([^"\n]+)"?,?$/gm, "\n$1" + commentLiterals + " $2");
+
+
+const configStringJson = JSON.stringify(configExample, null, 2);
 fs.writeFileSync(
   path.join(__dirname, ".markdownlint.jsonc"),
-  configStringJson,
+  transferComments(configStringJson, "//"),
   "utf8"
 );
 
-const configStringYaml = yaml.stringify(configExample, {
-  "lineWidth": 0,
-  "defaultStringType": "QUOTE_DOUBLE",
-  "defaultKeyType": "PLAIN"
-})
-  .replace(/^(\s*)[^-\s]+-sub-description: "(.+)"$/gm, "$1# $2")
-  .replace(/^[^-\s]+-description: "(.+)"$/gm, "\n# $1");
+const configStringYaml = yaml.stringify(configExample,
+  {
+    "lineWidth": 0,
+    "defaultStringType": "QUOTE_DOUBLE",
+    "defaultKeyType": "PLAIN"
+  });
 fs.writeFileSync(
   path.join(__dirname, ".markdownlint.yaml"),
-  // eslint-disable-next-line max-len
-  "# Example markdownlint YAML configuration with all properties set to their default value\n" +
-  configStringYaml,
+  transferComments(configStringYaml, "#"),
   "utf8"
 );

--- a/schema/build-config-example.js
+++ b/schema/build-config-example.js
@@ -26,31 +26,34 @@ for (const rule in configSchema.properties) {
   }
 }
 
-const transferComments = (input, commentLiterals) => commentLiterals +
+const transformComments = (input, commentPrefix) => (
+  commentPrefix +
   // eslint-disable-next-line max-len
   " Example markdownlint configuration with all properties set to their default value\n" +
   input
     // eslint-disable-next-line max-len
-    .replace(/^(\s*)"?[^-\s]+-sub-description"?: "?([^"\n]+)"?,?$/gm, "$1" + commentLiterals + " $2")
+    .replace(/^(\s*)[^-\s]+-sub-description"?: "?([^"\n]+)"?,?$/gm, "$1" + commentPrefix + " $2")
     // eslint-disable-next-line max-len
-    .replace(/^(\s*)"?[^-\s]+-description"?: "?([^"\n]+)"?,?$/gm, "\n$1" + commentLiterals + " $2");
-
+    .replace(/^(\s*)[^-\s]+-description"?: "?([^"\n]+)"?,?$/gm, "\n$1" + commentPrefix + " $2")
+);
 
 const configStringJson = JSON.stringify(configExample, null, 2);
 fs.writeFileSync(
   path.join(__dirname, ".markdownlint.jsonc"),
-  transferComments(configStringJson, "//"),
+  transformComments(configStringJson, "//"),
   "utf8"
 );
 
-const configStringYaml = yaml.stringify(configExample,
+const configStringYaml = yaml.stringify(
+  configExample,
   {
     "lineWidth": 0,
     "defaultStringType": "QUOTE_DOUBLE",
     "defaultKeyType": "PLAIN"
-  });
+  }
+);
 fs.writeFileSync(
   path.join(__dirname, ".markdownlint.yaml"),
-  transferComments(configStringYaml, "#"),
+  transformComments(configStringYaml, "#"),
   "utf8"
 );

--- a/schema/build-config-example.js
+++ b/schema/build-config-example.js
@@ -4,8 +4,8 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
+const yaml = require("yaml");
 const configSchema = require("./markdownlint-config-schema.json");
-const YAML = require("yaml");
 
 const configExample = {};
 for (const rule in configSchema.properties) {
@@ -37,7 +37,7 @@ fs.writeFileSync(
   "utf8"
 );
 
-const configStringYaml = YAML.stringify(configExample, {
+const configStringYaml = yaml.stringify(configExample, {
   "lineWidth": 0,
   "defaultStringType": "QUOTE_DOUBLE",
   "defaultKeyType": "PLAIN"


### PR DESCRIPTION
Fixed issue with generating YAML schema by using
`YAML.stringify` instead of string replacements
of the `JSON.stringigy` result.

closes: #721