### PR TITLE
Add missing `parsers` property to `RuleParams`

### DIFF
--- a/lib/markdownlint.d.ts
+++ b/lib/markdownlint.d.ts
@@ -8,7 +8,7 @@ export = markdownlint;
  */
 declare function markdownlint(options: Options | null, callback: LintCallback): void;
 declare namespace markdownlint {
-    export { markdownlintSync as sync, readConfig, readConfigSync, getVersion, promises, RuleFunction, RuleParams, MarkdownItToken, RuleOnError, RuleOnErrorInfo, RuleOnErrorFixInfo, Rule, Options, Plugin, ToStringCallback, LintResults, LintError, FixInfo, LintContentCallback, LintCallback, Configuration, RuleConfiguration, ConfigurationParser, ReadConfigCallback, ResolveConfigExtendsCallback };
+    export { markdownlintSync as sync, readConfig, readConfigSync, getVersion, promises, RuleFunction, RuleParams, ParserInfo, MarkdownItToken, RuleOnError, RuleOnErrorInfo, RuleOnErrorFixInfo, Rule, Options, Plugin, ToStringCallback, LintResults, LintError, FixInfo, LintContentCallback, LintCallback, Configuration, RuleConfiguration, ConfigurationParser, ReadConfigCallback, ResolveConfigExtendsCallback };
 }
 /**
  * Configuration options.
@@ -129,9 +129,30 @@ type RuleParams = {
      */
     frontMatterLines: string[];
     /**
+     * Tokens parsed by different parsers.
+     */
+    parsers: ParserInfo;
+    /**
      * Rule configuration.
      */
     config: RuleConfiguration;
+};
+/**
+ * Parser related information passed to rules.
+ */
+type ParserInfo = {
+    /**
+     * Markdownit parser info.
+     */
+    markdownit: {
+        tokens: MarkdownItToken[];
+    };
+    /**
+     * Micromark parser info.
+     */
+    micromark: {
+        tokens: micromark.Token[];
+    };
 };
 /**
  * Markdown-It token.
@@ -406,3 +427,4 @@ declare function extendConfigPromise(config: Configuration, file: string, parser
  * @returns {Promise<Configuration>} Configuration object.
  */
 declare function readConfigPromise(file: string, parsers?: ConfigurationParser[], fs?: any): Promise<Configuration>;
+import micromark = require("../helpers/micromark.cjs");

--- a/lib/markdownlint.js
+++ b/lib/markdownlint.js
@@ -554,6 +554,7 @@ function lintContent(
       aliasToRuleNames
     );
   // Parse content into parser tokens
+  /** @type {MarkdownItToken[]} */
   const markdownitTokens = md.parse(content, {});
   const micromarkTokens = micromark.parse(content);
   // Hide the content of HTML comments from rules
@@ -562,6 +563,7 @@ function lintContent(
   const lines = content.split(helpers.newLineRe);
   annotateAndFreezeTokens(markdownitTokens, lines);
   // Create (frozen) parameters for rules
+  /** @type {ParserInfo} */
   const parsers = Object.freeze({
     "markdownit": Object.freeze({
       "tokens": markdownitTokens
@@ -1290,8 +1292,20 @@ module.exports = markdownlint;
  * @property {MarkdownItToken[]} tokens Token objects from markdown-it.
  * @property {string[]} lines File/string lines.
  * @property {string[]} frontMatterLines Front matter lines.
+ * @property {ParserInfo} parsers Tokens parsed by different parsers.
  * @property {RuleConfiguration} config Rule configuration.
  */
+
+/**
+ * Parser related information passed to rules.
+ *
+ * @typedef {Object} ParserInfo
+ * @property {Object} markdownit Markdownit parser info.
+ * @property {MarkdownItToken[]} markdownit.tokens Tokens parsed by markdownit.
+ * @property {Object} micromark Micromark parser info.
+ * @property {micromark.Token[]} micromark.tokens Tokens parsed by micromark.
+ */
+
 
 /**
  * Markdown-It token.


### PR DESCRIPTION
## 📚Description

I've found that `RuleParams` type was missing the `parsers` property while playing around with the code.

What do you think about using type hints in rule declarations [like it is done in ESLint](https://github.com/eslint/eslint/blob/main/lib/rules/array-bracket-newline.js#L14)? It would elevate the developer experience when working with rules not just because of the type checking, but because of the added autocompletion and better syntax highlighting:

![image](https://github.com/DavidAnson/markdownlint/assets/31937175/a13afc05-7c0b-4813-8e69-0d02d174c46f)
![image](https://github.com/DavidAnson/markdownlint/assets/31937175/3eff1148-f97f-4c50-81e1-27d588888f22)
