### PR TITLE
Fix super-linter URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ and test cases came directly from that project.
 [nodejs-extensions]: https://github.com/Lombiq/NodeJs-Extensions
 [rubygems-mdl]: https://rubygems.org/gems/mdl
 [sublimelinter]: https://packagecontrol.io/packages/SublimeLinter-contrib-markdownlint
-[super-linter]: https://github.com/github/super-linter
+[super-linter]: https://github.com/super-linter/super-linter
 [vscode-markdownlint]: https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint
 
 ### References


### PR DESCRIPTION
The linked super-linter repo is a fork only:

![image](https://github.com/DavidAnson/markdownlint/assets/1366654/55f72123-f61a-47e4-82e2-84de5717b8fc)

This PR updates the URL to point to the main repository.