### PR TITLE
fix: Export types

### DIFF
--- a/micromark/package.json
+++ b/micromark/package.json
@@ -3,7 +3,13 @@
   "version": "0.1.9",
   "description": "A trivial package that re-exports some micromark functionality as a CommonJS module",
   "type": "commonjs",
-  "exports": "./micromark.cjs",
+  "exports": {
+    ".": {
+      "types": "./micromark.d.ts",
+      "default": "./micromark.cjs"
+    }
+  },
+  "main": "./micromark.cjs",
   "types": "./micromark.d.ts",
   "author": "David Anson (https://dlaa.me/)",
   "license": "MIT",


### PR DESCRIPTION
I'm using Markdownlint in my project and TypeScript is reporting the following problem:

```
node_modules/markdownlint/lib/markdownlint.d.ts:232:34 - error TS7016: Could not find a declaration file for module 'markdownlint-micromark'. '/home/regseb/dev/metalint/node_modules/markdownlint-micromark/micromark.cjs' implicitly has an 'any' type.
  Try `npm i --save-dev @types/markdownlint-micromark` if it exists or add a new declaration (.d.ts) file containing `declare module 'markdownlint-micromark';`

232 type MicromarkTokenType = import("markdownlint-micromark").TokenType;
```

I think [`exports`](https://nodejs.org/docs/latest/api/packages.html#exports) and [`types`](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) are _incompatible_. The pairs are :

- `main` / `types`
- `exports.default` / `exports.types`