### PR TITLE
Add `heading-style` in Prettier config

### DIFF
--- a/style/prettier.json
+++ b/style/prettier.json
@@ -7,6 +7,7 @@
   "code-fence-style": false,
   "emphasis-style": false,
   "heading-start-left": false,
+  "heading-style": false,
   "hr-style": false,
   "line-length": false,
   "list-indent": false,


### PR DESCRIPTION
Add [`heading-style`](https://github.com/DavidAnson/markdownlint/blob/v0.34.0/doc/md003.md) in configuration [`prettier.json`](https://github.com/DavidAnson/markdownlint/blob/v0.34.0/style/prettier.json), because Prettier formats titles ([Playground](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBiABAQQCoA10DOMAngDZzoASAjADpT2oYDCpEBcAJlnoSeVQBM6JvXoBlOPAAeMPmQo16AXlVr1GsVEky5RBUPoBaE6bPmtTDDnz6BlAMwgANCAgAHGAEtoBZKABDACcgiAB3AAVghD8UANIwgOI-VwAjIICwAGspcQCAWzgAGS8oOGQAM3iONIzs3PdM0oBzZBgggFc4Vw58rzbO7pACFvIARQ6IeErqoYArAmlxUbgJqfKkKtIakABHSfgI0PdYkACCIzKuLhcQdoCvUhbmCHz8gOQz0lJbkahm8iYGDtLypDqHOBBEplGbbIYACxg+VIAHV4V54ARGmA4JIoCNvAA3DHET5gAgpECEroASSgnAQMHEYCCXk8mHp4n4Gy2O3coQ4KIy7k+-LgHCChPKrlKEpgRwCzXesL5wQln3eQSynHCUFu-NKMBRXk4MHhyAAHAAGVxBOD7Lx2hVKj6bWauGABVLG03mpCCVwdDjYL2xXlDOD5VJcBmcIoBf4dRVwABiECC72BLU+AXBEBAAF8C0A)).