### PR TITLE
Group minor/patch Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,23 @@ updates:
       interval: "daily"
     target-branch: "next"
     versioning-strategy: "increase"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "npm"
     directory: "/micromark"
     schedule:
       interval: "daily"
     target-branch: "next"
     versioning-strategy: "increase"
+    groups:
+      micromark:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Major versions will still create individual PRs, but minor/patch ones are grouped together like https://github.com/canada-ca/ore-ero/pull/1915