### PR TITLE
chore: Create GitHub Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,37 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running?
+      options:
+        - CLI
+        - CLI 2
+        - VS Code
+        - GitHub Action
+      default: 0
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Markdownlint CLI issue tracker
+    url: https://github.com/igorshubovych/markdownlint-cli/issues
+    about: If the issue is related to original Markdownlint CLI
+  - name: Markdownlint CLI 2 issue tracker
+    url: https://github.com/DavidAnson/markdownlint-cli2/issues
+    about: If the issue is related to new Markdownlint CLI
+  - name: Markdownlint CLI 2 GitHub Action issue tracker
+    url: https://github.com/DavidAnson/markdownlint-cli2-action/issues
+    about: If the issue is related to new Markdownlint CLI
+  - name: Markdownlint VS Code extension issue tracker
+    url: https://github.com/DavidAnson/vscode-markdownlint/issues
+    about: If the issue is related to using Markdownlint inside VS Code

--- a/.github/ISSUE_TEMPLATE/new-rule.yml
+++ b/.github/ISSUE_TEMPLATE/new-rule.yml
@@ -1,0 +1,18 @@
+name: New Rule
+description: Suggest a new rule for Markdownlint.
+title: "[New rule]: "
+labels: ["new rule"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest a new rule!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true


### PR DESCRIPTION
Had this sitting around in drafts for awhile, but I'm not sure if it needs more work before you might accept it.
- Adds the Issue config, so users will have a little nudge to open Issues on the "correct" repo, instead of this one to start
- Use the new YAML forms to allow a little guided data collection
- Still allows the "blank" issue templates, if people don't like the config

I'm opening this on `main` instead of `dev` as the templates need to be on the default branch to work. Could open it against `dev`, but then they wouldn't show up till the next sync