### PR TITLE
Omit micromark parsing if there is no related rules

### DIFF
--- a/lib/markdownlint.mjs
+++ b/lib/markdownlint.mjs
@@ -490,12 +490,14 @@ function lintContent(
   const needMarkdownItTokens = enabledRuleList.some(
     (rule) => (rule.parser === "markdownit") || (rule.parser === undefined)
   );
+  const needMicromarkTokens = enabledRuleList.some(
+    (rule) => (rule.parser === "micromark")
+  );
   const customRulesPresent = (ruleList.length !== rules.length);
   // Parse content into parser tokens
-  const micromarkTokens = micromarkParse(
-    content,
-    { "freezeTokens": customRulesPresent }
-  );
+  const micromarkTokens = needMicromarkTokens ?
+    micromarkParse(content, { "freezeTokens": customRulesPresent }) :
+    [];
   // Hide the content of HTML comments from rules
   const preClearedContent = content;
   content = helpers.clearHtmlCommentText(content);


### PR DESCRIPTION
In cases where all default markdownlint rules are disabled
and only custom rules based on markdownit tokens are used.

For example:
The Diplodoc platform uses 9 custom rules,
all of which are implemented using markdownit.
All default markdownlint rules are disabled
(we use markdownlint only as a rule execution engine).

In this configuration, using micromark for parsing is not only unnecessary
but also significantly slows down the linting process.