### PR TITLE
feat(md033): add fix_strategy parameter

### DIFF
--- a/doc-build/md033.md
+++ b/doc-build/md033.md
@@ -16,6 +16,11 @@ specific set of HTML elements within Markdown tables, set the
 `table_allowed_elements` parameter to a list of HTML element names. This can be
 used to permit the use of `<br>`-style line breaks only within Markdown tables.
 
+To sanitize disallowed elements automatically, set the `fix_strategy` parameter:
+
+- `"escape"`: replaces `<my-example>` with `\<my-example>`
+- `"wrap"`: replaces `<my-example>` with `` `<my-example>` ``
+
 Rationale: Raw HTML is allowed in Markdown, but this rule is included for
 those who want their documents to only include "pure" Markdown, or for those
 who are rendering Markdown documents into something other than HTML.

--- a/doc/Rules.md
+++ b/doc/Rules.md
@@ -1342,8 +1342,12 @@ Aliases: `no-inline-html`
 Parameters:
 
 - `allowed_elements`: Allowed elements (`string[]`, default `[]`)
+- `fix_strategy`: Fix strategy to handle disallowed elements (`string`, default
+  `none`, values `wrap` / `escape` / `none`)
 - `table_allowed_elements`: Allowed elements in tables (`string[]`, default
   `[]`)
+
+Fixable: Some violations can be fixed by tooling
 
 This rule is triggered whenever raw HTML is used in a Markdown document:
 
@@ -1362,6 +1366,11 @@ To allow specific HTML elements anywhere in Markdown content, set the
 specific set of HTML elements within Markdown tables, set the
 `table_allowed_elements` parameter to a list of HTML element names. This can be
 used to permit the use of `<br>`-style line breaks only within Markdown tables.
+
+To sanitize disallowed elements automatically, set the `fix_strategy` parameter:
+
+- `"escape"`: replaces `<my-example>` with `\<my-example>`
+- `"wrap"`: replaces `<my-example>` with `` `<my-example>` ``
 
 Rationale: Raw HTML is allowed in Markdown, but this rule is included for
 those who want their documents to only include "pure" Markdown, or for those

--- a/doc/md033.md
+++ b/doc/md033.md
@@ -7,8 +7,12 @@ Aliases: `no-inline-html`
 Parameters:
 
 - `allowed_elements`: Allowed elements (`string[]`, default `[]`)
+- `fix_strategy`: Fix strategy to handle disallowed elements (`string`, default
+  `none`, values `wrap` / `escape` / `none`)
 - `table_allowed_elements`: Allowed elements in tables (`string[]`, default
   `[]`)
+
+Fixable: Some violations can be fixed by tooling
 
 This rule is triggered whenever raw HTML is used in a Markdown document:
 
@@ -27,6 +31,11 @@ To allow specific HTML elements anywhere in Markdown content, set the
 specific set of HTML elements within Markdown tables, set the
 `table_allowed_elements` parameter to a list of HTML element names. This can be
 used to permit the use of `<br>`-style line breaks only within Markdown tables.
+
+To sanitize disallowed elements automatically, set the `fix_strategy` parameter:
+
+- `"escape"`: replaces `<my-example>` with `\<my-example>`
+- `"wrap"`: replaces `<my-example>` with `` `<my-example>` ``
 
 Rationale: Raw HTML is allowed in Markdown, but this rule is included for
 those who want their documents to only include "pure" Markdown, or for those

--- a/lib/configuration-strict.d.ts
+++ b/lib/configuration-strict.d.ts
@@ -1177,6 +1177,10 @@ export interface ConfigurationStrict {
          * Allowed elements in tables
          */
         table_allowed_elements?: string[];
+        /**
+         * Fix strategy to handle disallowed elements
+         */
+        fix_strategy?: "wrap" | "escape" | "none";
       };
   /**
    * MD033/no-inline-html : Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.40.0/doc/md033.md
@@ -1201,6 +1205,10 @@ export interface ConfigurationStrict {
          * Allowed elements in tables
          */
         table_allowed_elements?: string[];
+        /**
+         * Fix strategy to handle disallowed elements
+         */
+        fix_strategy?: "wrap" | "escape" | "none";
       };
   /**
    * MD034/no-bare-urls : Bare URL used : https://github.com/DavidAnson/markdownlint/blob/v0.40.0/doc/md034.md

--- a/lib/constants.mjs
+++ b/lib/constants.mjs
@@ -6,9 +6,9 @@ export const fixableRuleNames = [
   "MD004", "MD005", "MD007", "MD009", "MD010", "MD011",
   "MD012", "MD014", "MD018", "MD019", "MD020", "MD021",
   "MD022", "MD023", "MD026", "MD027", "MD029", "MD030",
-  "MD031", "MD032", "MD034", "MD037", "MD038", "MD039",
-  "MD044", "MD047", "MD049", "MD050", "MD051", "MD053",
-  "MD054", "MD058"
+  "MD031", "MD032", "MD033", "MD034", "MD037", "MD038",
+  "MD039", "MD044", "MD047", "MD049", "MD050", "MD051",
+  "MD053", "MD054", "MD058"
 ];
 export const homepage = "https://github.com/DavidAnson/markdownlint";
 export const version = "0.40.0";

--- a/lib/md033.mjs
+++ b/lib/md033.mjs
@@ -19,6 +19,7 @@ export default {
     const allowedElements = toLowerCaseStringArray(params.config.allowed_elements);
     // If not defined, use allowedElements for backward compatibility
     const tableAllowedElements = toLowerCaseStringArray(params.config.table_allowed_elements || params.config.allowed_elements);
+    const fixStrategy = String(params.config.fix_strategy || "none");
     for (const token of filterByTypesCached([ "htmlText" ], true)) {
       const htmlTagInfo = getHtmlTagInfo(token);
       if (htmlTagInfo && !htmlTagInfo.close) {
@@ -28,16 +29,32 @@ export default {
           (inTable || !allowedElements.includes(elementName)) &&
           (!inTable || !tableAllowedElements.includes(elementName))
         ) {
+          const tagText = token.text.replace(nextLinesRe, "");
           const range = [
             token.startColumn,
-            token.text.replace(nextLinesRe, "").length
+            tagText.length
           ];
+          let fixInfo = undefined;
+          if ([ "escape", "wrap" ].includes(fixStrategy) && (token.startLine === token.endLine)) {
+            let insertText = undefined;
+            if (fixStrategy === "escape") {
+              insertText = `\\${tagText}`;
+            } else if (fixStrategy == "wrap") {
+              insertText = `\`${tagText}\``;
+            }
+            fixInfo = {
+              "editColumn": token.startColumn,
+              "deleteCount": tagText.length,
+              "insertText": insertText
+            };
+          }
           addError(
             onError,
             token.startLine,
             "Element: " + htmlTagInfo.name,
             undefined,
-            range
+            range,
+            fixInfo
           );
         }
       }

--- a/schema/.markdownlint.jsonc
+++ b/schema/.markdownlint.jsonc
@@ -176,7 +176,9 @@
     // Allowed elements
     "allowed_elements": [],
     // Allowed elements in tables
-    "table_allowed_elements": []
+    "table_allowed_elements": [],
+    // Fix strategy to handle disallowed elements
+    "fix_strategy": "none"
   },
 
   // MD034/no-bare-urls : Bare URL used : https://github.com/DavidAnson/markdownlint/blob/v0.40.0/doc/md034.md

--- a/schema/.markdownlint.yaml
+++ b/schema/.markdownlint.yaml
@@ -160,6 +160,8 @@ MD033:
   allowed_elements: []
   # Allowed elements in tables
   table_allowed_elements: []
+  # Fix strategy to handle disallowed elements
+  fix_strategy: "none"
 
 # MD034/no-bare-urls : Bare URL used : https://github.com/DavidAnson/markdownlint/blob/v0.40.0/doc/md034.md
 MD034: true

--- a/schema/build-config-schema.mjs
+++ b/schema/build-config-schema.mjs
@@ -389,6 +389,13 @@ for (const rule of rules) {
         },
         "default": []
       };
+      // @ts-ignore
+      subscheme.properties.fix_strategy = {
+        "description": "Fix strategy to handle disallowed elements",
+        "type": "string",
+        "enum": [ "wrap", "escape", "none" ],
+        "default": "none"
+      };
       break;
     case "MD035":
       // @ts-ignore

--- a/schema/markdownlint-config-schema-strict.json
+++ b/schema/markdownlint-config-schema-strict.json
@@ -2398,6 +2398,16 @@
                 "type": "string"
               },
               "default": []
+            },
+            "fix_strategy": {
+              "description": "Fix strategy to handle disallowed elements",
+              "type": "string",
+              "enum": [
+                "wrap",
+                "escape",
+                "none"
+              ],
+              "default": "none"
             }
           }
         }
@@ -2449,6 +2459,16 @@
                 "type": "string"
               },
               "default": []
+            },
+            "fix_strategy": {
+              "description": "Fix strategy to handle disallowed elements",
+              "type": "string",
+              "enum": [
+                "wrap",
+                "escape",
+                "none"
+              ],
+              "default": "none"
             }
           }
         }

--- a/schema/markdownlint-config-schema.json
+++ b/schema/markdownlint-config-schema.json
@@ -2398,6 +2398,16 @@
                 "type": "string"
               },
               "default": []
+            },
+            "fix_strategy": {
+              "description": "Fix strategy to handle disallowed elements",
+              "type": "string",
+              "enum": [
+                "wrap",
+                "escape",
+                "none"
+              ],
+              "default": "none"
             }
           }
         }
@@ -2449,6 +2459,16 @@
                 "type": "string"
               },
               "default": []
+            },
+            "fix_strategy": {
+              "description": "Fix strategy to handle disallowed elements",
+              "type": "string",
+              "enum": [
+                "wrap",
+                "escape",
+                "none"
+              ],
+              "default": "none"
             }
           }
         }


### PR DESCRIPTION
Allows auto-fixing disallowed inline HTML elements.

We have two use cases on MDN:

1. When using machine translation (from English to German), escaped/wrapped HTML elements in prose occasionally gets translated into an unescaped/unwrapped HTML element, causing markdownlint to fail. Auto-fixing allows to resolve these without manual intervention.
2. When contributors forget to wrap HTML elements in prose, they have to manually fix these. Auto-fixing allows us to auto-suggest the most obvious fix (in our case: wrapping in a code fence) via our reviewdog integration.