### PR TITLE
MD029: fix corrupted output for zero-padded list markers

### DIFF
--- a/lib/md029.mjs
+++ b/lib/md029.mjs
@@ -15,12 +15,13 @@ const listStyles = Object.keys(listStyleExamples);
  * Gets the column and text of an ordered list item prefix token.
  *
  * @param {import("markdownlint").MicromarkToken} listItemPrefix List item prefix token.
- * @returns {{column: number, value: number}} List item value column and text.
+ * @returns {{column: number, length: number, value: number}} List item value column, source length, and numeric value.
  */
 function getOrderedListItemValue(listItemPrefix) {
   const listItemValue = getDescendantsByType(listItemPrefix, [ "listItemValue" ])[0];
   return {
     "column": listItemValue.startColumn,
+    "length": listItemValue.text.length,
     "value": Number(listItemValue.text)
   };
 }
@@ -61,7 +62,7 @@ export default {
         const actual = orderedListItemValue.value;
         const fixInfo = {
           "editColumn": orderedListItemValue.column,
-          "deleteCount": orderedListItemValue.value.toString().length,
+          "deleteCount": orderedListItemValue.length,
           "insertText": expected.toString()
         };
         addErrorDetailIf(

--- a/test/markdownlint-test-scenarios.mjs.snapshot
+++ b/test/markdownlint-test-scenarios.mjs.snapshot
@@ -37361,6 +37361,98 @@ exports[`markdownlint-test-scenarios.mjs > ordered-list-item-prefix-zero-alterna
 }
 `;
 
+exports[`markdownlint-test-scenarios.mjs > ordered-list-item-prefix-zero-padded.md 1`] = `
+{
+  "errors": [
+    {
+      "lineNumber": 10,
+      "ruleNames": [
+        "MD029",
+        "ol-prefix"
+      ],
+      "ruleDescription": "Ordered list item prefix",
+      "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/v0.0.0/doc/md029.md",
+      "errorDetail": "Expected: 1; Actual: 8; Style: 1/2/3",
+      "errorContext": null,
+      "errorRange": [
+        1,
+        4
+      ],
+      "fixInfo": {
+        "editColumn": 1,
+        "deleteCount": 2,
+        "insertText": "1"
+      },
+      "severity": "error"
+    },
+    {
+      "lineNumber": 11,
+      "ruleNames": [
+        "MD029",
+        "ol-prefix"
+      ],
+      "ruleDescription": "Ordered list item prefix",
+      "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/v0.0.0/doc/md029.md",
+      "errorDetail": "Expected: 2; Actual: 9; Style: 1/2/3",
+      "errorContext": null,
+      "errorRange": [
+        1,
+        4
+      ],
+      "fixInfo": {
+        "editColumn": 1,
+        "deleteCount": 2,
+        "insertText": "2"
+      },
+      "severity": "error"
+    },
+    {
+      "lineNumber": 12,
+      "ruleNames": [
+        "MD029",
+        "ol-prefix"
+      ],
+      "ruleDescription": "Ordered list item prefix",
+      "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/v0.0.0/doc/md029.md",
+      "errorDetail": "Expected: 3; Actual: 10; Style: 1/2/3",
+      "errorContext": null,
+      "errorRange": [
+        1,
+        4
+      ],
+      "fixInfo": {
+        "editColumn": 1,
+        "deleteCount": 2,
+        "insertText": "3"
+      },
+      "severity": "error"
+    },
+    {
+      "lineNumber": 13,
+      "ruleNames": [
+        "MD029",
+        "ol-prefix"
+      ],
+      "ruleDescription": "Ordered list item prefix",
+      "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/v0.0.0/doc/md029.md",
+      "errorDetail": "Expected: 4; Actual: 11; Style: 1/2/3",
+      "errorContext": null,
+      "errorRange": [
+        1,
+        4
+      ],
+      "fixInfo": {
+        "editColumn": 1,
+        "deleteCount": 2,
+        "insertText": "4"
+      },
+      "severity": "error"
+    }
+  ],
+  "fixed": "# Ordered list item prefix zero-padded\\n\\nRegression test: zero-padded, multi-character list item markers used to be\\nmis-fixed because the delete count for the fix was computed from\\n\`Number(text).toString().length\` (the re-stringified numeric value) rather\\nthan the actual source text length. For \\"08.\\" that produced a delete count of\\n1 instead of 2, so fixing it inserted \\"1\\" without removing the full \\"08\\" and\\nleft \\"18.\\" behind instead of \\"1.\\".\\n\\n1. Item {MD029}\\n2. Item {MD029}\\n3. Item {MD029}\\n4. Item {MD029}\\n\\n<!-- markdownlint-configure-file {\\n  \\"ol-prefix\\": {\\n    \\"style\\": \\"ordered\\"\\n  }\\n} -->\\n"
+}
+`;
+
 exports[`markdownlint-test-scenarios.mjs > ordered-list-item-prefix-zero.md 1`] = `
 {
   "errors": [

--- a/test/markdownlint-test.mjs
+++ b/test/markdownlint-test.mjs
@@ -1091,7 +1091,7 @@ test.suite(import.meta.url.replace(/^.*?\/(?<name>[^/]*)$/u, "$<name>"), () => {
   });
 
   test("validateJsonUsingConfigSchemaStrict", async(t) => {
-    t.plan(235);
+    t.plan(236);
     // @ts-ignore
     const ajv = new Ajv(ajvOptions);
     const validateSchemaStrict = ajv.compile(configSchemaStrict);

--- a/test/ordered-list-item-prefix-zero-padded.md
+++ b/test/ordered-list-item-prefix-zero-padded.md
@@ -1,0 +1,19 @@
+# Ordered list item prefix zero-padded
+
+Regression test: zero-padded, multi-character list item markers used to be
+mis-fixed because the delete count for the fix was computed from
+`Number(text).toString().length` (the re-stringified numeric value) rather
+than the actual source text length. For "08." that produced a delete count of
+1 instead of 2, so fixing it inserted "1" without removing the full "08" and
+left "18." behind instead of "1.".
+
+08. Item {MD029}
+09. Item {MD029}
+10. Item {MD029}
+11. Item {MD029}
+
+<!-- markdownlint-configure-file {
+  "ol-prefix": {
+    "style": "ordered"
+  }
+} -->


### PR DESCRIPTION
The autofix works out how many characters to delete by re-stringifying the parsed number (`Number(text).toString().length`) instead of measuring the actual marker text. For a marker like `08.` that gives 1 instead of 2, so the fix only strips the leading `0` and leaves the rest behind — `08.` turns into `18.` instead of `1.`. Only shows up with leading zeros, which the MD029 doc explicitly calls out as supported for uniform indentation.

Fixed by keeping the source text length around instead of recomputing it from the number. Added a fixture with a zero-padded list that reproduces the corruption and confirmed the fixed output re-lints clean.