### PR TITLE
fix(shared): correct typo 'identifing' to 'identifying'

### DIFF
--- a/helpers/shared.cjs
+++ b/helpers/shared.cjs
@@ -2,7 +2,7 @@
 
 "use strict";
 
-// Symbol for identifing the flat tokens array from micromark parse
+// Symbol for identifying the flat tokens array from micromark parse
 module.exports.flatTokensSymbol = Symbol("flat-tokens");
 
 // Symbol for identifying the htmlFlow token from micromark parse


### PR DESCRIPTION
## Summary

Fixes #2149 — a spelling typo in a code comment detected by the `typos` spell checker.

- `helpers/shared.cjs:5`: `identifing` → `identifying`

## Test plan

- [x] `git diff` shows only the one-word comment change