### PR TITLE
Accept one space per side in an empty cell for MD060 style "compact"

### DIFF
--- a/doc-build/md060.md
+++ b/doc-build/md060.md
@@ -30,6 +30,18 @@ Style `compact` avoids extra padding with a single space around cell content:
 | N | No |
 ```
 
+An empty cell has no content, so a single space around that content is a gap of
+two characters. Both that and a single space are accepted for style `compact`,
+because table formatters differ in which of the two they emit:
+
+```markdown
+| Character | Meaning |
+| --- | --- |
+| Y | Yes |
+|  |  |
+| | |
+```
+
 Style `tight` uses no padding at all for cell content:
 
 ```markdown

--- a/doc/Rules.md
+++ b/doc/Rules.md
@@ -2773,6 +2773,18 @@ Style `compact` avoids extra padding with a single space around cell content:
 | N | No |
 ```
 
+An empty cell has no content, so a single space around that content is a gap of
+two characters. Both that and a single space are accepted for style `compact`,
+because table formatters differ in which of the two they emit:
+
+```markdown
+| Character | Meaning |
+| --- | --- |
+| Y | Yes |
+|  |  |
+| | |
+```
+
 Style `tight` uses no padding at all for cell content:
 
 ```markdown

--- a/doc/md060.md
+++ b/doc/md060.md
@@ -44,6 +44,18 @@ Style `compact` avoids extra padding with a single space around cell content:
 | N | No |
 ```
 
+An empty cell has no content, so a single space around that content is a gap of
+two characters. Both that and a single space are accepted for style `compact`,
+because table formatters differ in which of the two they emit:
+
+```markdown
+| Character | Meaning |
+| --- | --- |
+| Y | Yes |
+|  |  |
+| | |
+```
+
 Style `tight` uses no padding at all for cell content:
 
 ```markdown

--- a/lib/md060.mjs
+++ b/lib/md060.mjs
@@ -119,13 +119,28 @@ export default {
         }
         for (const row of rows) {
           const tokensOfInterest = filterByTypes(row.children, [ "tableCellDivider", "tableContent", "whitespace" ]);
+          // An empty cell has no tableContent token, so its padding is a single
+          // whitespace token between two dividers. Style "compact" allows one
+          // space on each side of cell content, so such a gap may be one or two
+          // characters, and it is reported once rather than once per side.
+          /** @type {Set<number>} */
+          const emptyCellGaps = new Set();
+          for (let i = 1; i < (tokensOfInterest.length - 1); i++) {
+            if (
+              (tokensOfInterest[i].type === "whitespace") &&
+              (tokensOfInterest[i - 1].type === "tableCellDivider") &&
+              (tokensOfInterest[i + 1].type === "tableCellDivider")
+            ) {
+              emptyCellGaps.add(i);
+            }
+          }
           for (let i = 0; i < tokensOfInterest.length; i++) {
             const { startColumn, startLine, type } = tokensOfInterest[i];
             if (type === "tableCellDivider") {
               const previous = tokensOfInterest[i - 1];
               if (previous) {
                 if (previous.type === "whitespace") {
-                  if (previous.text.length !== 1) {
+                  if (!emptyCellGaps.has(i - 1) && (previous.text.length > 1)) {
                     addError(
                       errorsIfCompact,
                       startLine,
@@ -155,13 +170,14 @@ export default {
               if (next) {
                 if (next.type === "whitespace") {
                   if (next.endColumn !== row.endColumn) {
-                    if (next.text.length !== 1) {
+                    const maximumCompact = emptyCellGaps.has(i + 1) ? 2 : 1;
+                    if (next.text.length > maximumCompact) {
                       addError(
                         errorsIfCompact,
                         startLine,
                         startColumn,
                         "Table pipe has extra space to the right for style \"compact\"",
-                        { "editColumn": next.startColumn, "deleteCount": next.text.length - 1 }
+                        { "editColumn": next.startColumn, "deleteCount": next.text.length - maximumCompact }
                       );
                     }
                     addError(

--- a/test/markdownlint-test-scenarios.mjs.snapshot
+++ b/test/markdownlint-test-scenarios.mjs.snapshot
@@ -54276,9 +54276,49 @@ exports[`markdownlint-test-scenarios.mjs > table-column-style-compact.md 1`] = `
         "insertText": " "
       },
       "severity": "error"
+    },
+    {
+      "lineNumber": 151,
+      "ruleNames": [
+        "MD060",
+        "table-column-style"
+      ],
+      "ruleDescription": "Table column style",
+      "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/v0.0.0/doc/md060.md",
+      "errorDetail": "Table pipe has extra space to the right for style \\"compact\\"",
+      "errorContext": null,
+      "errorRange": [
+        1,
+        1
+      ],
+      "fixInfo": {
+        "editColumn": 2,
+        "deleteCount": 1
+      },
+      "severity": "error"
+    },
+    {
+      "lineNumber": 151,
+      "ruleNames": [
+        "MD060",
+        "table-column-style"
+      ],
+      "ruleDescription": "Table column style",
+      "ruleInformation": "https://github.com/DavidAnson/markdownlint/blob/v0.0.0/doc/md060.md",
+      "errorDetail": "Table pipe has extra space to the right for style \\"compact\\"",
+      "errorContext": null,
+      "errorRange": [
+        5,
+        1
+      ],
+      "fixInfo": {
+        "editColumn": 6,
+        "deleteCount": 1
+      },
+      "severity": "error"
     }
   ],
-  "fixed": "# Table Column Style - Compact\\n\\n## Aligned / Edge Pipes\\n\\n| Heading | Heading | Heading |\\n| ------- | --------- | ------- |\\n| Text | Text text | Text |\\n| Text | Text text | Text |\\n| Text | Text text | Text |\\n\\n{MD060:-6} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\n| Heading | Heading | Heading |\\n| ------- | -------- | ------- |\\n| Text | Text text | Text |\\n| Text | Text text | Text |\\n| Text | Text tex | Text |\\n\\n{MD060:-6} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\n## Aligned / No Edge Pipes\\n\\nHeading | Heading | Heading\\n------- | --------- | -------\\nText | Text text | Text\\nText | Text text | Text\\nText | Text text | Text\\n\\n{MD060:-6} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\nHeading | Heading | Heading\\n------- | -------- | --------\\nText | Text text | Text\\nText | Text text | Text\\nText | Text tex | Text\\n\\n{MD060:-6} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\n## Compact / Edge Pipes\\n\\n| Heading | Heading | Heading |\\n| ------- | ------- | ------- |\\n| Text | Text text | Text |\\n| Text text | Text text text | Text |\\n| Text | Text | Text |\\n\\n| Heading | Heading | Heading |\\n| - | - | - |\\n| Text | Text text | Text |\\n| Text text | Text text text | Text |\\n| Text | Text | Text |\\n\\n| Heading | Heading | Heading |\\n| - | --- | - |\\n| Text | Text text | Text |\\n| Text | Text | Text |\\n| Text | Text | Text |\\n\\n{MD060:-6} {MD060:-5} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\n## Compact / No Edge Pipes\\n\\nHeading | Heading | Heading\\n------- | ------- | -------\\nText | Text text | Text\\nText text | Text text text | Text\\nText | Text | Text\\n\\nHeading | Heading | Heading\\n-- | -- | --\\nText | Text text | Text\\nText text | Text text text | Text\\nText | Text | Text\\n\\nHeading | Heading | Heading\\n-- | --- | --\\nText | Text text | Text\\nText text | Text text text | Text\\nText | Text | Text\\n\\n{MD060:-6} {MD060:-5} {MD060:-4} {MD060:-2}\\n\\n## Tight / Edge Pipes\\n\\n| Heading | Heading | Heading |\\n| ------- | ------- | ------- |\\n| Text | Text text | Text |\\n| Text text | Text text text | Text |\\n| Text | Text | Text |\\n\\n{MD060:-6} {MD060:-5} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\n| Heading | Heading | Heading |\\n| -- | -- | -- |\\n| Text | Text text | Text |\\n| Text text | Text text text | Text |\\n| Text | Text | Text |\\n\\n{MD060:-6} {MD060:-5} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\n| Heading | Heading | Heading |\\n| ------- | ------- | ------- |\\n| Text | Text text | Text |\\n| Text text | Text text text | Text |\\n| Text | Text | Text |\\n\\n{MD060:-6} {MD060:-5} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\n## Tight / No Edge Pipes\\n\\nHeading | Heading | Heading\\n------- | ------- | -------\\nText | Text text | Text\\nText text | Text text text | Text\\nText | Text | Text\\n\\n{MD060:-6} {MD060:-5} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\nHeading | Heading | Heading\\n-- | -- | --\\nText | Text text | Text\\nText text | Text text text | Text\\nText | Text | Text\\n\\n{MD060:-6} {MD060:-5} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\nHeading | Heading | Heading\\n------- | ------- | -------\\nText | Text text | Text\\nText text | Text text text | Text\\nText | Text | Text\\n\\n{MD060:-6} {MD060:-5} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\n<!-- markdownlint-configure-file {\\n  \\"table-column-style\\": {\\n    \\"style\\": \\"compact\\"\\n  },\\n  \\"table-pipe-style\\": false\\n} -->\\n"
+  "fixed": "# Table Column Style - Compact\\n\\n## Aligned / Edge Pipes\\n\\n| Heading | Heading | Heading |\\n| ------- | --------- | ------- |\\n| Text | Text text | Text |\\n| Text | Text text | Text |\\n| Text | Text text | Text |\\n\\n{MD060:-6} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\n| Heading | Heading | Heading |\\n| ------- | -------- | ------- |\\n| Text | Text text | Text |\\n| Text | Text text | Text |\\n| Text | Text tex | Text |\\n\\n{MD060:-6} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\n## Aligned / No Edge Pipes\\n\\nHeading | Heading | Heading\\n------- | --------- | -------\\nText | Text text | Text\\nText | Text text | Text\\nText | Text text | Text\\n\\n{MD060:-6} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\nHeading | Heading | Heading\\n------- | -------- | --------\\nText | Text text | Text\\nText | Text text | Text\\nText | Text tex | Text\\n\\n{MD060:-6} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\n## Compact / Edge Pipes\\n\\n| Heading | Heading | Heading |\\n| ------- | ------- | ------- |\\n| Text | Text text | Text |\\n| Text text | Text text text | Text |\\n| Text | Text | Text |\\n\\n| Heading | Heading | Heading |\\n| - | - | - |\\n| Text | Text text | Text |\\n| Text text | Text text text | Text |\\n| Text | Text | Text |\\n\\n| Heading | Heading | Heading |\\n| - | --- | - |\\n| Text | Text text | Text |\\n| Text | Text | Text |\\n| Text | Text | Text |\\n\\n{MD060:-6} {MD060:-5} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\n## Compact / No Edge Pipes\\n\\nHeading | Heading | Heading\\n------- | ------- | -------\\nText | Text text | Text\\nText text | Text text text | Text\\nText | Text | Text\\n\\nHeading | Heading | Heading\\n-- | -- | --\\nText | Text text | Text\\nText text | Text text text | Text\\nText | Text | Text\\n\\nHeading | Heading | Heading\\n-- | --- | --\\nText | Text text | Text\\nText text | Text text text | Text\\nText | Text | Text\\n\\n{MD060:-6} {MD060:-5} {MD060:-4} {MD060:-2}\\n\\n## Tight / Edge Pipes\\n\\n| Heading | Heading | Heading |\\n| ------- | ------- | ------- |\\n| Text | Text text | Text |\\n| Text text | Text text text | Text |\\n| Text | Text | Text |\\n\\n{MD060:-6} {MD060:-5} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\n| Heading | Heading | Heading |\\n| -- | -- | -- |\\n| Text | Text text | Text |\\n| Text text | Text text text | Text |\\n| Text | Text | Text |\\n\\n{MD060:-6} {MD060:-5} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\n| Heading | Heading | Heading |\\n| ------- | ------- | ------- |\\n| Text | Text text | Text |\\n| Text text | Text text text | Text |\\n| Text | Text | Text |\\n\\n{MD060:-6} {MD060:-5} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\n## Tight / No Edge Pipes\\n\\nHeading | Heading | Heading\\n------- | ------- | -------\\nText | Text text | Text\\nText text | Text text text | Text\\nText | Text | Text\\n\\n{MD060:-6} {MD060:-5} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\nHeading | Heading | Heading\\n-- | -- | --\\nText | Text text | Text\\nText text | Text text text | Text\\nText | Text | Text\\n\\n{MD060:-6} {MD060:-5} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\nHeading | Heading | Heading\\n------- | ------- | -------\\nText | Text text | Text\\nText text | Text text text | Text\\nText | Text | Text\\n\\n{MD060:-6} {MD060:-5} {MD060:-4} {MD060:-3} {MD060:-2}\\n\\n## Compact / Empty Cells\\n\\nAn empty cell has no content, so one space on each side of that content is a\\ntwo-character gap. Both that and a single space are accepted.\\n\\n| Heading | Heading |\\n| ------- | ------- |\\n|  |  |\\n| | |\\n| Text | Text |\\n| Text |  |\\n\\nA gap of three or more spaces is still extra padding, reported once per cell.\\n\\n| Heading | Heading |\\n| ------- | ------- |\\n|  |  |\\n\\n{MD060:-2} {MD060:-2}\\n\\n<!-- markdownlint-configure-file {\\n  \\"table-column-style\\": {\\n    \\"style\\": \\"compact\\"\\n  },\\n  \\"table-pipe-style\\": false\\n} -->\\n"
 }
 `;
 

--- a/test/table-column-style-compact.md
+++ b/test/table-column-style-compact.md
@@ -132,6 +132,26 @@ Text| Text |Text
 
 {MD060:-6} {MD060:-5} {MD060:-4} {MD060:-3} {MD060:-2}
 
+## Compact / Empty Cells
+
+An empty cell has no content, so one space on each side of that content is a
+two-character gap. Both that and a single space are accepted.
+
+| Heading | Heading |
+| ------- | ------- |
+|  |  |
+| | |
+| Text | Text |
+| Text |  |
+
+A gap of three or more spaces is still extra padding, reported once per cell.
+
+| Heading | Heading |
+| ------- | ------- |
+|   |   |
+
+{MD060:-2} {MD060:-2}
+
 <!-- markdownlint-configure-file {
   "table-column-style": {
     "style": "compact"


### PR DESCRIPTION
Fixes #2196.

## Problem

Style `compact` applies a different padding rule to empty cells than to cells with content. A cell with content needs one space on each side, an empty cell is only allowed one space in total:

| cell | before | after |
| :--- | :--- | :--- |
| `\| a \|` | 0 | 0 |
| `\|a\|` | 2, missing space | 2, missing space |
| `\|  a  \|` | 2, extra space | 2, extra space |
| `\| \|` | 0 | 0 |
| `\|  \|` | 2, extra space | 0 |
| `\|   \|` | 2, extra space | 1, extra space |

`doc/md060.md` describes the style as "avoids extra padding with a single space around cell content", which reads as one space per side, so `|  |` failing looked unintended.

## Cause

A cell with content has two `whitespace` tokens, one on each side of the `tableContent` token, and each is checked once against a length of 1.

An empty cell has no `tableContent` token, so micromark emits a single `whitespace` token spanning the whole gap. That one token was then checked twice, once as the right padding of the preceding divider and once as the left padding of the following divider, each time against a length of 1. A two-character gap, which is one space per side, therefore failed both checks, and a three-character gap produced the same two errors.

## Change

Precompute which `whitespace` tokens are bounded by `tableCellDivider` tokens on both sides. Such a token is the padding of an empty cell, so for style `compact` it may be up to two characters and it is reported once rather than once per side.

A single space stays valid, so existing files and existing `--fix` output are unaffected. A gap of three or more is still reported, and now fixes to two rather than one.

Cells with content are untouched, and style `tight` is untouched.

## Verification

`npm test` passes, 677 tests, `lib/md060.mjs` at 100% coverage. `npm run lint` is clean, and `npm run serial-config-docs` regenerated `doc/md060.md` and `doc/Rules.md`, both committed.

Notably the snapshot diff is confined to the fixture section I added, so nothing in the existing corpus changed behaviour. Added coverage to `test/table-column-style-compact.md` for a two-space empty cell, a one-space empty cell, an empty cell in a mixed row, and a three-space gap.

## Why it matters

Table formatters commonly implement padding uniformly as "one space, content, one space", which yields two spaces for an empty cell. Output of that shape is internally consistent but was reported under every style, including `any`, and the fix rewrote it. Where such a formatter also owns the files, the two tools revert each other on every save. In my repository that was roughly 59,600 violations across 1,818 of 2,142 files from empty cells alone.

Happy to adjust the shape if you would rather express this as an option or a separate style than as a change to `compact`.